### PR TITLE
Added optional base parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ shortHash('a string to hash...');
 
 ## API
 
-### `shortHash(str)`
+### `shortHash(input, [base])`
 
-| Name | Type | Description |
-|------|------|-------------|
-| str | `String` | The string to hash |
+| Name   | Type     | Description        |
+| ------ | -------- | ------------------ |
+| input  | `String` | The string to hash |
+| [base] | `String` | The string to hash |
 
-Returns: `String`, a hexadecimal string.
+Returns: `String`, a hash of any string with the provided base.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "short-hash",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Get a short hash from a string. Uses Bernstein's popular 'times 33' hash algorithm but returns a hex string instead of a number",
   "main": "src/index.js",
   "typings": "./src/types.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "short-hash",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Get a short hash from a string. Uses Bernstein's popular 'times 33' hash algorithm but returns a hex string instead of a number",
   "main": "src/index.js",
+  "typings": "./src/types.d.ts",
   "scripts": {
     "lint": "xo",
     "pretest": "npm run -s lint",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var hash = require('hash-string');
 
-module.exports = function shortHash(str) {
-  return hash(str).toString(16);
+module.exports = function shortHash(str, base) {
+  return hash(str).toString(base || 16);
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,3 @@
+/** Returns a hexadecimal hash of any string */
+function shortHash(input: string): string
+export = shortHash

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,13 @@
-/** Returns a hexadecimal hash of any string */
+/** 
+ * Returns a hash of any string with the provided base
+ * @param {string} input - The string to hash
+ * @param {number} [base=16] - The base of the returned string. An integer from 2 through 36
+*/
+function shortHash(input: string, base = 16): string
+
+/** 
+ * Returns a hexadecimal hash of any string 
+ * @param {string} input - The string to hash
+*/
 function shortHash(input: string): string
 export = shortHash

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 'use strict';
 var test = require('tape');
-var shortHash = require('../src');
+var shortHash = require('../');
 
 test('shortHash generates a small hash from a string', function (assert) {
   var str = 'Lorem ipsum dolor sit amet, et nec eros partem integre, ' +

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,11 @@ test('shortHash generates a small hash from a string', function (assert) {
     'Et utamur definitionem eos, natum sadipscing voluptatibus usu et. ' +
     'No omnesque intellegat vel, cum prima tollit democritum an. ' +
     'Fuisset copiosae mel ei, in utroque meliore lucilius has. Ancillae incorrupte ut has.';
+
   assert.equal(shortHash(str), 'cf74ec25');
+  assert.equal(shortHash(str, 16), 'cf74ec25');
+  assert.equal(shortHash(str, 27), '8qf71qk');
+  assert.equal(shortHash(str, 36), '1lk86qt');
+
   assert.end();
 });


### PR DESCRIPTION
I added the option to use an other base than base 16.
All you have to do is just provide any base between 16 and 36 as the second argument:
```javascript
shortHash('a string to hash...', 27);
// "8qf71qk"
```
16 is still the default base and the function can be used with only one argument, as usual

This builds on my previous pull request that adds typings (#3).
If that doesn't gets pulled, it can be removed from this branch